### PR TITLE
Ensure Dsn::$parameters is defined before sending to parse_str

### DIFF
--- a/src/Configuration/Dsn.php
+++ b/src/Configuration/Dsn.php
@@ -57,10 +57,10 @@ final class Dsn
         $this->username = $parts['user'] ?? null;
         $this->password = $parts['pass'] ?? null;
         $this->vhost = $parts['path'] === '/' ? self::DEFAULT_VHOST : substr($parts['path'], 1);
+        
+        $this->parameters = [];
 
         if (! isset($parts['query'])) {
-            $this->parameters = [];
-
             return;
         }
 

--- a/src/Configuration/Dsn.php
+++ b/src/Configuration/Dsn.php
@@ -34,7 +34,7 @@ final class Dsn
     private $vhost;
 
     /** @var string[] */
-    private $parameters;
+    private $parameters = [];
 
     public function __construct(string $dsn)
     {
@@ -57,8 +57,6 @@ final class Dsn
         $this->username = $parts['user'] ?? null;
         $this->password = $parts['pass'] ?? null;
         $this->vhost = $parts['path'] === '/' ? self::DEFAULT_VHOST : substr($parts['path'], 1);
-        
-        $this->parameters = [];
 
         if (! isset($parts['query'])) {
             return;


### PR DESCRIPTION
It's fine at the moment (PHP silently changes the `null` value to `[]`), but if eventually you add an `array` property type to $parameters, PHP will complain:

https://3v4l.org/KBsHt (and caught by Psalm in https://psalm.dev/r/950f433b4b)