### PR TITLE
fix: use correct content-type header name

### DIFF
--- a/src/RabbitMQ/Message.php
+++ b/src/RabbitMQ/Message.php
@@ -6,6 +6,7 @@ namespace Cdn77\RabbitMQBundle\RabbitMQ;
 
 class Message
 {
+    public const HEADER_CONTENT_TYPE = 'content-type';
     public const HEADER_DELIVERY_MODE = 'delivery-mode';
 
     /** @var string */
@@ -29,7 +30,7 @@ class Message
     /** @param mixed[] $headers */
     public static function json(string $body, array $headers = []): self
     {
-        return new self($body, ['Content-Type' => 'application/json'] + $headers);
+        return new self($body, [self::HEADER_CONTENT_TYPE => 'application/json'] + $headers);
     }
 
     public static function fromBunny(\Bunny\Message $message): self

--- a/tests/RabbitMQ/MessageTest.php
+++ b/tests/RabbitMQ/MessageTest.php
@@ -25,7 +25,7 @@ final class MessageTest extends TestCase
     {
         $message = Message::json('json string');
 
-        self::assertArrayHasKey('Content-Type', $message->headers);
-        self::assertSame('application/json', $message->headers['Content-Type']);
+        self::assertArrayHasKey(Message::HEADER_CONTENT_TYPE, $message->headers);
+        self::assertSame('application/json', $message->headers[Message::HEADER_CONTENT_TYPE]);
     }
 }


### PR DESCRIPTION
Same as https://github.com/cdn77/RabbitMQBundle/pull/32